### PR TITLE
Change engine support to Node v6.

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     "test-travis": "node --harmony ./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha --report lcovonly"
   },
   "engines": {
-    "node": ">= 7.6.0"
+    "node": ">= 6"
   }
 }


### PR DESCRIPTION
Currently, `webpack-serve` cannot be installed with Yarn on a Node v6 system because this module's package.json only support v7.6.0 or greater. Since you've added Node v6 support to the module, can the package.json be updated as well?

```
error @shellscape/koa-static@4.0.4: The engine "node" is incompatible with this module. Expected version ">= 7.6.0".
```